### PR TITLE
Enable FORCE_NKRO in Fuyu HS

### DIFF
--- a/keyboards/zykrah/fuyu_hs/config.h
+++ b/keyboards/zykrah/fuyu_hs/config.h
@@ -19,6 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 500U
 
+#define FORCE_NKRO
+
 #ifdef RGB_MATRIX_ENABLE
 /* The pin connected to the data pin of the LEDs */
 #define RGB_DI_PIN GP3


### PR DESCRIPTION
Even though NKRO feature is enabled in `info.json`, the keyboard is still in 6KRO mode. Also, Magic N command described in [FAQ](https://github.com/qmk/qmk_firmware/blob/master/docs/faq_misc.md#nkro-doesnt-work) does not work, as bootmagic feature is disabled by default in `info.json`.

By using `FORCE_NKRO` option, it's possible to turn on NKRO feature, and also won't hassle people who are not used to building firmwares with QMK.